### PR TITLE
Update documentation, allow for frontMatter

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,6 @@
   "default": true,
   "MD033": false,
   "MD013": false,
-  "MD036": false
+  "MD036": false,
+  "MD041": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,6 +2,5 @@
   "default": true,
   "MD033": false,
   "MD013": false,
-  "MD036": false,
-  "MD041": false
+  "MD036": false
 }

--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ This repository enforces [Conventional Commit](https://www.conventionalcommits.o
 documentation for [`release-please`](https://github.com/googleapis/release-please#how-should-i-write-my-commits) for
 correctly formatting commit messages
 
+#### Prerequisites 
+
+[Hugo](https://gohugo.io/documentation/) is required in order to utilize the doc site template. You can run `brew install hugo` to quickly install or see the [installation page](https://gohugo.io/installation/) for additional install methods.
+
 ## Getting Started
 
-Create a new repository from this template
+Create a new repository from this template:
 
 ![How to use](static/img/how-to-use.png)
 
-Clone your new site
+Clone your new site:
 
 ```bash
 git clone <git repo>

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ which is a fork of the Google Docsy theme. The Docsy documentation can be used a
 ## Contributing
 
 This repository enforces [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) messages. See the
-documentation for [`release-please`](https://github.com/googleapis/release-please#how-should-i-write-my-commits) for
-correctly formatting commit messages
+documentation for [`release-please`](https://github.com/googleapis/release-please#how-should-i-write-my-commits) for correctly formatting commit messages. [This video](https://www.youtube.com/watch?v=lwGcnDgwmFc&ab_channel=Syntax) does a good job of showing how to add the `Conventional Commit` VSCode extension to use when creating the commit messages.
 
 #### Prerequisites 
 

--- a/content/en/docs/codeSample.md
+++ b/content/en/docs/codeSample.md
@@ -1,8 +1,12 @@
-<!--
 ---
 title: Code Sample
 description: Samples of code
 ---
+<!-- 
+In certain instances a markdown viewer may not display due to
+the '---' frontmatter block above. If you're one of those edge
+cases enclose the frontmatter at the top of this file entirely
+within a comment block just like this comment.
 -->
 
 ```bash

--- a/content/en/docs/codeSample.md
+++ b/content/en/docs/codeSample.md
@@ -1,7 +1,9 @@
+<!--
 ---
 title: Code Sample
 description: Samples of code
 ---
+-->
 
 ```bash
 echo "This is bash"

--- a/content/en/docs/diagrams.md
+++ b/content/en/docs/diagrams.md
@@ -1,8 +1,12 @@
-<!--
 ---
 title: Mermaid Diagram Samples
 description: Mermaid
 ---
+<!-- 
+In certain instances a markdown viewer may not display due to
+the '---' frontmatter block above. If you're one of those edge
+cases enclose the frontmatter at the top of this file entirely
+within a comment block just like this comment.
 -->
 
 ```mermaid

--- a/content/en/docs/diagrams.md
+++ b/content/en/docs/diagrams.md
@@ -1,7 +1,9 @@
+<!--
 ---
 title: Mermaid Diagram Samples
 description: Mermaid
 ---
+-->
 
 ```mermaid
 graph TD

--- a/hugo.toml
+++ b/hugo.toml
@@ -2,6 +2,31 @@ baseURL         = "https://example.com/"
 enableGitInfo   = true
 enableRobotsTXT = true
 
+# Set uglyURLs & relativeURLs for hugo to build local offline pages in public/
+# When these are set `npm start` will no longer host functioning webpages. Instead
+#   use `npm run build` to construct the offline public/ directory 
+uglyURLs = false
+relativeURLs = false
+
+# Mount any external directories for use by hugo
+# 
+# source: 
+#   The source directory of the mount. For the main project, this can be either 
+#   project-relative or absolute and even a symbolic link. For other modules it must be 
+#   project-relative.
+# target
+#   Where it should be mounted into Hugo’s virtual filesystem. It must start with one of 
+#   Hugo’s component folders: static, content, layouts, data, assets, i18n, or archetypes. 
+#   E.g. content/blog.
+
+# [[module.mounts]]
+#   source = '../docs/*.md'
+#   target = 'content/en/docs'
+
+[[module.mounts]]
+  source = "content/en"
+  target = "content"
+
 [module]
   proxy = "direct"
 
@@ -61,9 +86,6 @@ enableRobotsTXT = true
 ### Mermaid theme choices
 #[params.mermaid]
 # theme = "neutral" # You can override this default dark theme with other Mermaid themes
-[[module.mounts]]
-  source = "content/en"
-  target = "content"
 
 ## The following merge in theme defaults from: https://github.com/defenseunicorns/defense-unicorns-hugo-theme/tree/main/config/_default
 [markup]


### PR DESCRIPTION
Our pipelines team in Delivery is integrating the docs site template into our projects to improve the way we do documentation and standardize with the overall company's efforts. This PR contains any additional instructions, context, and information from our experience in utilizing the template.

We were able to add support for frontMatter in order to allow for markdown compatibility. 