### PR TITLE
Feature/offline docs

### DIFF
--- a/doc-site-template-utils/README.md
+++ b/doc-site-template-utils/README.md
@@ -1,0 +1,68 @@
+# README.md for /doc-site-template/js/make_offline_webpage.js
+
+## Prerequisites:
+Before using the `make_offline_webpage.js` script and cloning the `doc-site-template` repository, ensure that you have the following pre-requisites set up:
+
+1. **Git:** Make sure you have Git installed on your system. You can download it from the official website: [Git Downloads](https://git-scm.com/downloads).
+
+2. **doc-site-template** Clone Defense Unicorn's [doc-site-template](https://github.com/defenseunicorns/doc-site-template) to the root of your project.
+
+3. **Node.js and npm:** The `make_offline_webpage.js` script uses Node.js and npm to manage dependencies and execute scripts. Ensure you have both Node.js and npm installed. You can download them from the official website: [Node.js Downloads](https://nodejs.org/en/download/).
+
+
+## Overview:
+The `/doc-site-template/js/make_offline_webpage.js` script is an essential part of the process that enables the creation of an offline webpage. The webpage is generated using the Defense Unicorns hugo theme, which takes the content from your project's `README.md` and converts it into an offline-friendly html format.
+
+## Setup:
+Before using this script, ensure you have cloned the 'doc-site-template' repository from 'https://github.com/defenseunicorns/doc-site-template.git'. This directory structure should look like:
+
+```arduino
+Copy code
+your_project/
+    │
+    ├── docs/
+    │   ├── doc-site-template-utils/
+    │   │   ├── js/
+    │   │   │   ├── make_offline_webpage.js
+    │   ├── your_docs.md
+    |   ├── your_other_docs.md
+    |   ├── your_other_other_docs_and_so_on.md
+    ├── doc-site-template git clone
+    |   ├── content/
+    |   |   ├── en/
+    |   |   |   ├── docs/
+    |   |   |   |   ├── your_docs.md
+    |   |   |   |   ├── your_other_docs.md
+    ├── ... (other files of your project)
+```
+
+## Functionality:
+The `make_offline_webpage.js` script performs the following tasks to build the offline webpage:
+
+1. Modifies `package.json`: The script updates the 'scripts' section in the 'package.json' file of the 'doc-site-template' project. Specifically, it adds a new script named 'build-D' that runs `hugo -D` to construct the `public` webpage directory without starting a web server.
+
+2. Modifies `hugo.toml`: The script makes necessary changes to the 'hugo.toml' configuration file of the 'doc-site-template' project. Namely it ensures that `uglyURLs` and `relativeURLs` are set to `true`.  This is what instructs hugo to make the webpage work offline.
+
+## Usage:
+To use the `make_offline_webpage.js` script effectively, follow these steps:
+
+1. Navigate to the `doc-site-template` git cloned directory in your project.
+
+2. Run the script using Node.js:
+```bash
+node ../docs/doc-site-template-utils/js/make_offline_webpage.js
+```
+
+3. Once the script completes its execution, you can generate the offline webpage by running the following command:
+```bash
+npm run build-D
+```
+
+This will invoke the Hugo webpage builder, which will take the content from your project's `README.md`, apply the configurations from 'hugo.toml', and produce an offline webpage.
+
+## Additional Notes:
+- It is essential to review the modifications made to 'package.json' and 'hugo.toml' by the script to ensure they align with your project requirements.
+
+- The generated offline webpage will be available in the 'public' directory inside the 'doc-site-template' folder. You can view the offline webpage by opening the 'index.html' file in a web browser.
+
+- You can further customize the appearance and behavior of the offline webpage by adjusting the configurations in 'hugo.toml', or by using Hugo themes and templates.

--- a/doc-site-template-utils/gitlab-ci-examples/.gitlab-ci.yml
+++ b/doc-site-template-utils/gitlab-ci-examples/.gitlab-ci.yml
@@ -3,13 +3,6 @@
 stages:
   - build_docs
 
-variables:
-  PYTHON_FOLDER: "../python-utils/" # Where we will stage our python utils for all stages
-  PACKAGE_NAME: "py_utils"
-  RUN_PY_GITLAB_UTILS: "python3 ${PYTHON_FOLDER} gitlab"
-  RUN_PY_SAME_OR_HIGHER: "python3 ${PYTHON_FOLDER}/__version__.py -cmd same_or_higher"
-  RUN_PY_DL: "python3 ${PYTHON_FOLDER} download"
-
 build_docs:
   stage: build_docs
   artifacts:

--- a/doc-site-template-utils/gitlab-ci-examples/.gitlab-ci.yml
+++ b/doc-site-template-utils/gitlab-ci-examples/.gitlab-ci.yml
@@ -1,0 +1,65 @@
+# Example gitlab-ci.yml stage that uses make_offline_webpage.js which captures all of
+# your markdown files (<proj root>/docs/*.md) and creates an offline website.
+stages:
+  - build_docs
+
+variables:
+  PYTHON_FOLDER: "../python-utils/" # Where we will stage our python utils for all stages
+  PACKAGE_NAME: "py_utils"
+  RUN_PY_GITLAB_UTILS: "python3 ${PYTHON_FOLDER} gitlab"
+  RUN_PY_SAME_OR_HIGHER: "python3 ${PYTHON_FOLDER}/__version__.py -cmd same_or_higher"
+  RUN_PY_DL: "python3 ${PYTHON_FOLDER} download"
+
+build_docs:
+  stage: build_docs
+  artifacts:
+    paths:
+      - "${CI_PROJECT_DIR}/docs/public"
+      - "${CI_PROJECT_DIR}/docs/*.html"
+      - "${CI_PROJECT_DIR}/docs/*.md"
+  variables:
+    HUGO_VERSION: "0.115.4"  # Replace with the desired Hugo version
+    HUGO_ARCH: "Linux-64bit"
+    HUGO_BINARY: "hugo_${HUGO_VERSION}_${HUGO_ARCH}.tar.gz"
+    HUGO_URL: "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY}"
+    HUGO_INSTALL_DIR: "/usr/local/bin"
+    GO_VERSION: "1.19.12"
+    GO_ARCH: "linux-amd64"
+    GO_BINARY: "go${GO_VERSION}.${GO_ARCH}.tar.gz"
+  before_script:
+    - dnf install -y wget
+    - mkdir -p temp
+    # Install Golang
+    - |
+      wget -q --tries=3 -P temp https://go.dev/dl/${GO_BINARY}
+      tar -C /usr/local -xzf temp/${GO_BINARY}
+      # Add Go binary directory to PATH
+      export PATH=$PATH:/usr/local/go/bin
+      go version # Verify Golang installation
+    # Install NPM
+    - |
+      curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+      . ~/.nvm/nvm.sh
+      nvm install node
+    # Download and install Hugo
+    - |
+      wget -q --tries=3 -P temp ${HUGO_URL}
+      tar -zxvf temp/${HUGO_BINARY}
+      mv -f hugo ${HUGO_INSTALL_DIR}
+      hugo version # Verify Hugo installation
+    # Clone doc-site-template
+    - git clone https://github.com/defenseunicorns/doc-site-template.git temp/doc-site-template
+  script:
+    - cd temp/
+    # Prep docs-site-template to create offline webpages using Node.js script
+    # Pass path to where our markdown doc files are
+    - node $CI_PROJECT_DIR/docs/doc-site-template-utils/js/make_offline_webpage.js --md-path $CI_PROJECT_DIR/docs
+    # doc-site-template ops
+    - cd doc-site-template
+    - npm ci
+    # Build 'public' folder for offline use
+    - npm run build-D
+    # Move hugo public dir to docs
+    - mv -f public $CI_PROJECT_DIR/docs/public
+    # create shortcut in public/ parent directory
+    - ln -sf $CI_PROJECT_DIR/docs/public/docs.html $CI_PROJECT_DIR/docs/docs.html

--- a/doc-site-template-utils/js/make_offline_webpage.js
+++ b/doc-site-template-utils/js/make_offline_webpage.js
@@ -1,0 +1,177 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync } = require('child_process');
+const docSiteTemplatePath = 'doc-site-template';
+const packageJsonPath = docSiteTemplatePath + '/package.json';
+const hugoTomlPath = docSiteTemplatePath + '/hugo.toml';
+const exampleDocsPath = docSiteTemplatePath + '/content/en/docs';
+// const markdownDocsPath = 'docs/*.md';
+
+let toml, tomlify, glob;
+
+// Function to check if a package is installed
+function isPackageInstalled(packageName) {
+  try {
+    require.resolve(packageName);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+// Function to create a temporary directory
+function createTempDir() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'npm-temp-'));
+  console.log('Created temporary directory:', tempDir);
+  return tempDir;
+}
+
+// Function to remove a directory and its contents recursively
+function removeDirRecursive(dir) {
+  if (fs.existsSync(dir)) {
+    fs.readdirSync(dir).forEach(file => {
+      const filePath = path.join(dir, file);
+      if (fs.lstatSync(filePath).isDirectory()) {
+        removeDirRecursive(filePath);
+      } else {
+        fs.unlinkSync(filePath);
+      }
+    });
+    fs.rmdirSync(dir);
+  }
+}
+
+// Function to install missing dependencies in a temporary directory
+function installMissingDependencies() {
+  const modulesToInstall = ['toml', 'glob', 'tomlify-j0.4', 'yargs'];
+  const tempDir = createTempDir();
+  let originalNodePath; // Define the variable outside of the try block
+
+  try {
+    // Modify the NODE_PATH to include the temporary directory
+    originalNodePath = process.env.NODE_PATH; // Assign the current NODE_PATH to the variable
+    process.env.NODE_PATH = path.join(tempDir, 'node_modules');
+    require('module').Module._initPaths(); // Refresh module paths
+
+    for (const module of modulesToInstall) {
+      // Use the --prefix flag to specify the temporary directory for installation
+      console.log(`Installing '${module}' package to temp directory...`);
+      execSync(`npm install --prefix ${tempDir} ${module}`);
+      console.log(`'${module}' package installed successfully.`);
+    }
+
+    // Call main()
+    main();
+
+  } catch (error) {
+    console.error('Error installing dependencies:', error.message);
+  } finally {
+    // Restore the original NODE_PATH
+    process.env.NODE_PATH = originalNodePath;
+    require('module').Module._initPaths(); // Refresh module paths
+
+    // Remove the temporary directory and its contents after the script is done
+    removeDirRecursive(tempDir);
+    console.log('Removed temporary directory:', tempDir);
+  }
+}
+
+// Function to to modify git cloned doc-site-template/package.json
+function modifyPackageJson() {
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  packageJson.scripts['build-D'] = "hugo -D";
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+  console.log("Modified 'scripts' in package.json with 'build-D: 'hugo -D'");
+}
+
+// Function to modify git cloned doc-site-template/hugo.toml
+function modifyHugoToml() {
+  const tomlify = require('tomlify-j0.4');
+  const toml = require('toml');
+  const content = fs.readFileSync(hugoTomlPath, 'utf8');
+
+  // Parse the TOML content into a JavaScript object
+  const parsedToml = toml.parse(content);
+
+  // Modify the 'uglyURLs' and 'relativeURLs' properties
+  parsedToml.uglyURLs = true;
+  parsedToml.relativeURLs = true;
+
+  // Convert the modified object to TOML format
+  const modifiedContent = tomlify.toToml(parsedToml);
+
+  if (modifiedContent === content) {
+      console.log("'uglyURLs' and 'relativeURLs' are already set to true.");
+  } else {
+      fs.writeFileSync(hugoTomlPath, modifiedContent);
+      console.log("Modified 'uglyURLs' and 'relativeURLs' in hugo.toml");
+  }
+}
+
+// Function to remove example docs and copy your markdown docs
+function updateDocs(markdownDocsPath) {
+  const glob = require('glob');
+  try {
+    // Get a list of all files in the exampleDocsPath directory
+    const filesInExampleDocs = glob.sync(path.join(exampleDocsPath, '*'));
+    console.log('Found example markdown files:\n' + filesInExampleDocs.join('\n'));
+    // Filter out the files you want to keep (e.g., _index.md)
+    const filesToKeep = filesInExampleDocs.filter(file => path.basename(file) === '_index.md');
+
+    // Remove all other files
+    for (const file of filesInExampleDocs) {
+      if (!filesToKeep.includes(file)) {
+        fs.unlinkSync(file);
+        console.log('Removed: ' + file);
+      }
+    }
+
+    // Copy your markdown docs
+    console.log('Trying to get markdown files from: ' + markdownDocsPath);
+    const markdownFiles = glob.sync(markdownDocsPath);
+    console.log('Found markdown files:\n' + markdownFiles.join('\n'));
+    for (const file of markdownFiles) {
+      const baseFileName = path.basename(file);
+      if (baseFileName !== '_index.md') {
+        const fileExtension = path.extname(file);
+        const newFileName = path.join(exampleDocsPath, baseFileName);
+        fs.copyFileSync(file, newFileName);
+        console.log('Copied: ' + file);
+      } else {
+        console.log('Skipped: ' + file + ' (file with name "_index.md" ignored)');
+      }
+    }
+  } catch (error) {
+    console.error('Error updating docs:', error.message);
+  }
+}
+
+// Main function to execute all modifications
+function main() {
+  // Initialize the argument parser (using 'yargs' in this example)
+  const argv = require('yargs')
+    .option('md-path', {
+      alias: 'm',
+      describe: 'Path to the markdown documentation files',
+      demandOption: true, // Mark the argument as required
+      type: 'string', // Set the type of the argument (in this case, a string)
+      normalize: true, // Normalize the path to remove trailing slashes, etc.
+    })
+    .argv;
+
+  // Get the markdownDocsPath from the parsed arguments
+  let markdownDocsPath = argv['md-path'];
+
+  // Append the wildcard pattern to the markdownDocsPath
+  markdownDocsPath = path.join(markdownDocsPath, '*.md');
+
+  // installMissingDependencies();
+  modifyPackageJson();
+  modifyHugoToml();
+  updateDocs(markdownDocsPath);
+}
+
+// main() is called within because this creates a temp dir to install missing node modules then deletes them
+installMissingDependencies();
+// main();


### PR DESCRIPTION
## Merge Request Description

Utility to automate necessary changes to doc-site-utils for creating offline docs pages.  Also included examples of how to use in a gitlab CI pipeline.

## What Was Changed, Added, or Removed

1. doc-site-template-utils/ contains JS and gitlab CI example.

## Tech Debt

1. make_offline_webpage.js installs required node modules to a temp directory and points node to it.  Once the script is done it reverts that path.  Might be a better way to do this.
2. Explicit version requirements for make_offline_webpage.js was not implemented.

## Notes

The larger goal of this was to demonstrate to @bdfinst how my team is going forward with integrating doc-site-template into our GitLab CI Pipeline.  Maybe it will spark ideas on how to build it into the existing structure instead of it being an add-on.